### PR TITLE
feat: Add confirmationRequired parameter to BiometricHelper on Android

### DIFF
--- a/ksafe/src/androidMain/kotlin/eu/anifantakis/lib/ksafe/BiometricHelper.kt
+++ b/ksafe/src/androidMain/kotlin/eu/anifantakis/lib/ksafe/BiometricHelper.kt
@@ -66,6 +66,12 @@ object BiometricHelper {
     var promptSubtitle: String = "Authenticate to access secure data"
 
     /**
+     * Whether users must explicitly confirm after successful biometric recognition.
+     * Keep `true` for sensitive actions; set `false` to allow faster passive-auth flows.
+     */
+    var confirmationRequired: Boolean = true
+
+    /**
      * Initialize activity tracking. Called automatically by KSafe.
      */
     fun init(application: Application) {
@@ -292,6 +298,7 @@ object BiometricHelper {
                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
                     .setTitle(promptTitle)
                     .setSubtitle(subtitle)
+                    .setConfirmationRequired(confirmationRequired)
                     .setAllowedAuthenticators(
                         BiometricManager.Authenticators.BIOMETRIC_STRONG or
                         BiometricManager.Authenticators.DEVICE_CREDENTIAL


### PR DESCRIPTION
This PR adds a `confirmationRequired` parameter to the `BiometricHelper` on Android.

By default, biometric prompts often require an explicit user action (such as tapping a "Confirm" button) after a successful biometric scan. This change allows developers to bypass that step for a more seamless user experience when appropriate.

Reference: https://developer.android.com/identity/sign-in/biometric-auth#no-explicit-user-action