### PR TITLE
Add ability to define custom save location - but for 2.0.0

### DIFF
--- a/ksafe/src/jvmMain/kotlin/eu/anifantakis/lib/ksafe/KSafe.jvm.kt
+++ b/ksafe/src/jvmMain/kotlin/eu/anifantakis/lib/ksafe/KSafe.jvm.kt
@@ -46,6 +46,7 @@ private val fileNameRegex = Regex("[a-z][a-z0-9_]*")
  */
 fun KSafe(
     fileName: String? = null,
+    baseDirFile: File? = null,
     lazyLoad: Boolean = false,
     memoryPolicy: KSafeMemoryPolicy = KSafeMemoryPolicy.ENCRYPTED,
     config: KSafeConfig = KSafeConfig(),
@@ -53,6 +54,7 @@ fun KSafe(
     plaintextCacheTtl: Duration = 5.seconds,
 ): KSafe = buildJvmKSafe(
     fileName = fileName,
+    baseDirFile = baseDirFile,
     lazyLoad = lazyLoad,
     memoryPolicy = memoryPolicy,
     config = config,
@@ -68,6 +70,7 @@ fun KSafe(
 @PublishedApi
 internal fun KSafe(
     fileName: String? = null,
+    baseDirFile: File? = null,
     lazyLoad: Boolean = false,
     memoryPolicy: KSafeMemoryPolicy = KSafeMemoryPolicy.ENCRYPTED,
     config: KSafeConfig = KSafeConfig(),
@@ -76,6 +79,7 @@ internal fun KSafe(
     testEngine: KSafeEncryption,
 ): KSafe = buildJvmKSafe(
     fileName = fileName,
+    baseDirFile = baseDirFile,
     lazyLoad = lazyLoad,
     memoryPolicy = memoryPolicy,
     config = config,
@@ -86,6 +90,7 @@ internal fun KSafe(
 
 private fun buildJvmKSafe(
     fileName: String?,
+    baseDirFile: File?,
     lazyLoad: Boolean,
     memoryPolicy: KSafeMemoryPolicy,
     config: KSafeConfig,
@@ -101,12 +106,15 @@ private fun buildJvmKSafe(
     val dataStore: DataStore<Preferences> = PreferenceDataStoreFactory.create(
         scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
         produceFile = {
-            val homeDir = Paths.get(System.getProperty("user.home")).toFile()
-            val baseDir = File(homeDir, ".eu_anifantakis_ksafe")
-            if (!baseDir.exists()) {
-                baseDir.mkdirs()
-                secureDirectory(baseDir)
-            }
+            val baseDir = if(baseDirFile == null) {
+                val homeDir = Paths.get(System.getProperty("user.home")).toFile()
+                val homeBaseDir = File(homeDir, ".eu_anifantakis_ksafe")
+                if (!homeBaseDir.exists()) {
+                    homeBaseDir.mkdirs()
+                    secureDirectory(homeBaseDir)
+                }
+                homeBaseDir
+            } else baseDirFile
             val base = fileName?.let { "eu_anifantakis_ksafe_datastore_$it" }
                 ?: "eu_anifantakis_ksafe_datastore"
             File(baseDir, "$base.preferences_pb")

--- a/ksafe/src/jvmTest/kotlin/eu/anifantakis/lib/ksafe/JvmFileNameTest.kt
+++ b/ksafe/src/jvmTest/kotlin/eu/anifantakis/lib/ksafe/JvmFileNameTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.test.*
 import kotlinx.serialization.Serializable
+import java.nio.file.Files
 
 /**
  * Exhaustive tests for custom file names (letters-only).
@@ -63,6 +64,19 @@ class JvmFileNameTest {
         KSafe("abc123")
         KSafe("with_underscore")
         KSafe("data_v2")
+    }
+
+    /** Verfied if ksafe file gets stored on developers defined directory */
+    @Test
+    fun baseDirPath_allows_changing_default_directory() = runTest {
+        val tmpDir = Files.createTempDirectory("tmpKsafeTest").toFile()
+
+        val safe = KSafe("temporary_ksafe", tmpDir)
+        safe.put("hello", "world")
+
+        assertEquals(tmpDir.list().size, 1)
+
+        tmpDir.deleteRecursively()
     }
 
     /** Verifies filename validation rejects invalid characters */


### PR DESCRIPTION
Adds the ability to define a custom location to save the storage file.

This allows it to store all application data in one directory, such as in the work directory itself or somewhere in appdata (windows)

Reason for new branch: https://github.com/ioannisa/KSafe/pull/24#issuecomment-4320635943